### PR TITLE
Support TrueOG Bootstrap

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,19 @@ dependencies {
     compileOnly("com.comphenix.protocol:ProtocolLib:5.1.0") // Import ProtocolLib API.
 }
 
+tasks.named<ProcessResources>("processResources") {
+    val props = mapOf(
+        "version" to version,
+        "apiVersion" to apiVersion
+    )
+
+    inputs.properties(props) // Indicates to rerun if version changes.
+
+    filesMatching("plugin.yml") {
+        expand(props)
+    }
+}
+
 tasks.withType<AbstractArchiveTask>().configureEach { // Ensure reproducible builds.
     isPreserveFileTimestamps = false
     isReproducibleFileOrder = true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,60 +14,35 @@ group = "nl.skbotnl.rewindfixog" // Declare bundle identifier.
 version = "1.2.1" // Declare plugin version (will be in .jar).
 val apiVersion = "1.19" // Declare minecraft server target version.
 
-tasks.named<ProcessResources>("processResources") {
-    val props = mapOf(
-        "version" to version,
-        "apiVersion" to apiVersion
-    )
-
-    inputs.properties(props) // Indicates to rerun if version changes.
-
-    filesMatching("plugin.yml") {
-        expand(props)
-    }
-}
-
-repositories {
-    mavenCentral()
-    gradlePluginPortal()
-    maven {
-        url = uri("https://repo.purpurmc.org/snapshots")
-    }
-    maven {
-        url = uri("https://repo.viaversion.com")
-    }
-    maven {
-        url = uri("https://repo.dmulloy2.net/repository/public")
-    }
-    maven {
-        url = uri("https://hub.spigotmc.org/nexus/content/repositories/snapshots")
-    }
-    maven {
-        url = uri("https://oss.sonatype.org/content/repositories/snapshots") // Spigot dependency.
-    }
-    maven {
-        url = uri("https://oss.sonatype.org/content/repositories/central") // Spigot dependency.
-    }
-    maven {
-        url = uri("file://${System.getProperty("user.home")}/.m2/repository") // Import BuildTools from MavenLocal.
-    }
-}
-
-// Attempt to add SELF_MAVEN_LOCAL_REPO from the TrueOG Bootstrap as a Maven repo if available.
-val selfMavenLocalRepo = System.getenv("SELF_MAVEN_LOCAL_REPO") ?: System.getProperty("SELF_MAVEN_LOCAL_REPO")
+val selfMavenLocalRepo = System.getProperty("SELF_MAVEN_LOCAL_REPO")
+var addedBootstrapRepo = false
 if (selfMavenLocalRepo != null) {
     val repoFile = file(selfMavenLocalRepo)
     if (repoFile.exists()) {
+        println("Using SELF_MAVEN_LOCAL_REPO at: $selfMavenLocalRepo")
         repositories {
             maven {
                 url = uri("file://${repoFile.absolutePath}")
             }
         }
+        addedBootstrapRepo = true
     } else {
-        logger.error("ERROR: You must build remapped Spigot BuildTools before compiling this plugin. You can use the TrueOG Bootstrap to do this automatically.")
+        logger.error("ERROR: You must build remapped Spigot BuildTools before compiling this plugin. Use the TrueOG Bootstrap.")
     }
 } else {
-    logger.error("ERROR: You must build remapped Spigot BuildTools before compiling this plugin. You can use the TrueOG Bootstrap to do this automatically.")
+    logger.error("ERROR: You must build remapped Spigot BuildTools before compiling this plugin. Use the TrueOG Bootstrap.")
+}
+
+repositories {
+    mavenCentral()
+    gradlePluginPortal()
+    maven("https://repo.purpurmc.org/snapshots")
+    maven("https://repo.viaversion.com")
+    maven("https://repo.dmulloy2.net/repository/public")
+    maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots")
+    maven("https://oss.sonatype.org/content/repositories/snapshots")
+    maven("https://oss.sonatype.org/content/repositories/central")
+    maven("file://${System.getProperty("user.home")}/.m2/repository")
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,16 +31,16 @@ repositories {
     mavenCentral()
     gradlePluginPortal()
     maven {
-        url = uri("https://repo.purpurmc.org/snapshots/")
+        url = uri("https://repo.purpurmc.org/snapshots")
     }
     maven {
-        url = uri("https://repo.viaversion.com/")
+        url = uri("https://repo.viaversion.com")
     }
     maven {
-        url = uri("https://repo.dmulloy2.net/repository/public/")
+        url = uri("https://repo.dmulloy2.net/repository/public")
     }
     maven {
-        url = uri("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
+        url = uri("https://hub.spigotmc.org/nexus/content/repositories/snapshots")
     }
     maven {
         url = uri("https://oss.sonatype.org/content/repositories/snapshots") // Spigot dependency.
@@ -53,14 +53,30 @@ repositories {
     }
 }
 
+// Attempt to add SELF_MAVEN_LOCAL_REPO from the TrueOG Bootstrap as a Maven repo if available.
+val selfMavenLocalRepo = System.getenv("SELF_MAVEN_LOCAL_REPO") ?: System.getProperty("SELF_MAVEN_LOCAL_REPO")
+if (selfMavenLocalRepo != null) {
+    val repoFile = file(selfMavenLocalRepo)
+    if (repoFile.exists()) {
+        repositories {
+            maven {
+                url = uri("file://${repoFile.absolutePath}")
+            }
+        }
+    } else {
+        logger.error("ERROR: You must build remapped Spigot BuildTools before compiling this plugin. You can use the TrueOG Bootstrap to do this automatically.")
+    }
+} else {
+    logger.error("ERROR: You must build remapped Spigot BuildTools before compiling this plugin. You can use the TrueOG Bootstrap to do this automatically.")
+}
+
 dependencies {
     compileOnly("org.spigotmc:spigot-api:1.19.4-R0.1-SNAPSHOT")
     compileOnly("org.spigotmc:spigot:1.19.4-R0.1-SNAPSHOT")
- compileOnly("io.github.miniplaceholders:miniplaceholders-api:2.2.3") // Import MiniPlaceholders API.
+    compileOnly("io.github.miniplaceholders:miniplaceholders-api:2.2.3") // Import MiniPlaceholders API.
     compileOnly("org.purpurmc.purpur:purpur-api:1.19.4-R0.1-SNAPSHOT") // Import Purpur API.
     compileOnly("com.viaversion:viaversion-api:5.0.5") // Import ViaVersion API.
     compileOnly("com.comphenix.protocol:ProtocolLib:5.1.0") // Import ProtocolLib API.
-
 }
 
 tasks.withType<AbstractArchiveTask>().configureEach { // Ensure reproducible builds.
@@ -102,3 +118,4 @@ java {
         vendor = JvmVendorSpec.GRAAL_VM
     }
 }
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,23 +14,21 @@ group = "nl.skbotnl.rewindfixog" // Declare bundle identifier.
 version = "1.2.1" // Declare plugin version (will be in .jar).
 val apiVersion = "1.19" // Declare minecraft server target version.
 
-val selfMavenLocalRepo = System.getProperty("SELF_MAVEN_LOCAL_REPO")
-var addedBootstrapRepo = false
-if (selfMavenLocalRepo != null) {
-    val repoFile = file(selfMavenLocalRepo)
-    if (repoFile.exists()) {
-        println("Using SELF_MAVEN_LOCAL_REPO at: $selfMavenLocalRepo")
+val customMavenLocal = System.getProperty("SELF_MAVEN_LOCAL_REPO")
+if (customMavenLocal != null) {
+    val mavenLocalDir = file(customMavenLocal)
+    if (mavenLocalDir.isDirectory) {
+        println("Using SELF_MAVEN_LOCAL_REPO at: $customMavenLocal")
         repositories {
             maven {
-                url = uri("file://${repoFile.absolutePath}")
+                url = uri("file://${mavenLocalDir.absolutePath}")
             }
         }
-        addedBootstrapRepo = true
     } else {
-        logger.error("ERROR: You must build remapped Spigot BuildTools before compiling this plugin. Use the TrueOG Bootstrap.")
+        logger.error("TrueOG Bootstrap not found, defaulting to ~/.m2 for mavenLocal()")
     }
 } else {
-    logger.error("ERROR: You must build remapped Spigot BuildTools before compiling this plugin. Use the TrueOG Bootstrap.")
+    logger.error("TrueOG Bootstrap not found, defaulting to ~/.m2 to mavenLocal()")
 }
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,13 +34,13 @@ if (customMavenLocal != null) {
 repositories {
     mavenCentral()
     gradlePluginPortal()
+    mavenLocal()
     maven("https://repo.purpurmc.org/snapshots")
     maven("https://repo.viaversion.com")
     maven("https://repo.dmulloy2.net/repository/public")
     maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots")
     maven("https://oss.sonatype.org/content/repositories/snapshots")
     maven("https://oss.sonatype.org/content/repositories/central")
-    maven("file://${System.getProperty("user.home")}/.m2/repository")
 }
 
 dependencies {


### PR DESCRIPTION
This enables the TrueOG Bootstrap to declare its own maven local directory. This is in service of keeping everything in the bootstrap self-contained in one folder. If the variable is not passed, the plugin will build as normal using the default system mavenlocal.

```
$~/Downloads/RewindFix-OG$ ./gradlew -DSELF_MAVEN_LOCAL_REPO=~/Downloads/true-og/bootstrap/.m2/repository clean build

> Configure project :
Using SELF_MAVEN_LOCAL_REPO at: ~/Downloads/true-og/bootstrap/.m2/repository

BUILD SUCCESSFUL in 42s
```