### PR TITLE
Prevent repository overriding

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,23 +14,6 @@ group = "nl.skbotnl.rewindfixog" // Declare bundle identifier.
 version = "1.2.1" // Declare plugin version (will be in .jar).
 val apiVersion = "1.19" // Declare minecraft server target version.
 
-val customMavenLocal = System.getProperty("SELF_MAVEN_LOCAL_REPO")
-if (customMavenLocal != null) {
-    val mavenLocalDir = file(customMavenLocal)
-    if (mavenLocalDir.isDirectory) {
-        println("Using SELF_MAVEN_LOCAL_REPO at: $customMavenLocal")
-        repositories {
-            maven {
-                url = uri("file://${mavenLocalDir.absolutePath}")
-            }
-        }
-    } else {
-        logger.error("TrueOG Bootstrap not found, defaulting to ~/.m2 for mavenLocal()")
-    }
-} else {
-    logger.error("TrueOG Bootstrap not found, defaulting to ~/.m2 to mavenLocal()")
-}
-
 repositories {
     mavenCentral()
     gradlePluginPortal()
@@ -41,6 +24,20 @@ repositories {
     maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots")
     maven("https://oss.sonatype.org/content/repositories/snapshots")
     maven("https://oss.sonatype.org/content/repositories/central")
+    val customMavenLocal = System.getProperty("SELF_MAVEN_LOCAL_REPO")
+    if (customMavenLocal != null) {
+        val mavenLocalDir = file(customMavenLocal)
+        if (mavenLocalDir.isDirectory) {
+            println("Using SELF_MAVEN_LOCAL_REPO at: $customMavenLocal")
+            maven {
+                url = uri("file://${mavenLocalDir.absolutePath}")
+            }
+        } else {
+            logger.error("TrueOG Bootstrap not found, defaulting to ~/.m2 for mavenLocal()")
+        }
+    } else {
+        logger.error("TrueOG Bootstrap not found, defaulting to ~/.m2 to mavenLocal()")
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Under certain conditions, the other repositories will not be considered for the build. This moves the custom repo declaration to the end so that all standard repositories are considered first.